### PR TITLE
feat: add pagination in hub dashboard

### DIFF
--- a/src/jupyter/hub/components/HubDashboard.tsx
+++ b/src/jupyter/hub/components/HubDashboard.tsx
@@ -11,12 +11,13 @@ import {
   Flash,
   Label,
   PageLayout,
+  Pagination,
   RelativeTime,
   TextInput
 } from '@primer/react';
 import { Table, DataTable } from '@primer/react/drafts';
 import { PencilIcon, SearchIcon } from '@primer/octicons-react';
-import { HubState } from '../Store';
+import { HubState, User } from '../Store';
 
 import './../../../../style/jupyterhub/server-dashboard.css';
 
@@ -34,14 +35,15 @@ const HubManager = (props: {
   const base_url = window.location.origin || '/';
   const [errorAlert, setErrorAlert] = useState<string | null>(null);
 
-  const user_data = useSelector<HubState, any>(state => state.user_data);
-  const user_page = useSelector<HubState, { offset: number; limit: number }>(
+  const user_data = useSelector<HubState, User[]>(state => state.user_data);
+  const user_page = useSelector<HubState, HubState['user_page']>(
     state => state.user_page
   );
   const name_filter = useSelector<HubState, string>(state => state.name_filter);
 
   const offset = user_page ? user_page.offset : 0;
   const limit = user_page ? user_page.limit : 10;
+  const total = user_page ? user_page.total : undefined;
 
   const dispatch = useDispatch();
 
@@ -53,6 +55,15 @@ const HubManager = (props: {
     startAll,
     stopAll
   } = props;
+
+  const setOffset = (offset: any) => {
+    dispatch({
+      type: 'USER_OFFSET',
+      value: {
+        offset: offset
+      }
+    });
+  };
 
   const dispatchPageUpdate = (data: any, page: any) => {
     dispatch({
@@ -240,7 +251,7 @@ const HubManager = (props: {
     name: string;
     admin: string;
     serverName: string;
-    lastActivity: number;
+    lastActivity: number | null;
     serverReady: boolean;
     serverURL: string;
   }[] = servers.map((server: any, index: number) => {
@@ -407,6 +418,19 @@ const HubManager = (props: {
               ]}
             />
           </Table.Container>
+          {total && (
+            <Pagination
+              pageCount={Math.ceil(total / limit)}
+              currentPage={Math.floor(offset / limit) + 1}
+              onPageChange={e => {
+                e.preventDefault();
+                const el = e.target as HTMLAnchorElement;
+                const targetPage = parseInt(el.href.split('#').pop() as string);
+                const currPage = Math.floor(offset / limit) + 1;
+                setOffset(offset + limit * (targetPage - currPage));
+              }}
+            />
+          )}
         </PageLayout.Content>
         <PageLayout.Pane>
           <Button

--- a/src/jupyter/hub/components/group/GroupEdit.tsx
+++ b/src/jupyter/hub/components/group/GroupEdit.tsx
@@ -43,7 +43,6 @@ const GroupEdit = (props: {
   const dispatch = useDispatch();
 
   const dispatchPageUpdate = (data: any, page: any) => {
-    console.log(data, page);
     dispatch({
       type: 'GROUPS_PAGE',
       value: {
@@ -144,7 +143,6 @@ const GroupEdit = (props: {
             setGroupProps((prevProps: Record<string, string>) => {
               const newProps = { ...prevProps };
               delete newProps[props.groupKey];
-              console.log(newProps, props.groupKey);
               return newProps;
             });
           }}
@@ -282,7 +280,6 @@ const GroupEdit = (props: {
   const [newPropKey, setNewPropKey] = useState('');
   const [newPropValue, setNewPropValue] = useState('');
 
-  console.log(groupProps, group_data.properties);
   return (
     <>
       <PageLayout>

--- a/src/jupyter/hub/components/group/Groups.tsx
+++ b/src/jupyter/hub/components/group/Groups.tsx
@@ -29,7 +29,6 @@ const Groups = (props: {
   );
   const dispatch = useDispatch();
 
-  console.log(groups_data, groups_page);
   const offset = groups_page ? groups_page.offset : 0;
 
   const setOffset = (offset: any) => {


### PR DESCRIPTION
Adds pagination to the DataTable:

<img width="100%" alt="Screenshot 2023-05-15 at 8 36 32 PM" src="https://github.com/datalayer/jupyter-manager/assets/64399555/5a49661d-d347-49d9-bb01-4a922cee4822">
